### PR TITLE
Refactor config and add snapshot tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+dev:
+FLASK_APP=run.py FLASK_ENV=development flask run
+
+test:
+pytest -q
+
+lint:
+ruff check .

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,44 +1,62 @@
 import os
-from flask import Flask, redirect, url_for
+import logging
+from flask import Flask, redirect, url_for, render_template
 from flask_sqlalchemy import SQLAlchemy
 from flask_migrate import Migrate
 from dotenv import load_dotenv
+
+from .config import DevConfig, ProdConfig
 
 # Initialize extensions
 db = SQLAlchemy()
 migrate = Migrate()
 
-def create_app():
+
+def create_app(config_name: str | None = None) -> Flask:
+    """Application factory with environment based configuration."""
     load_dotenv()
+
     project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-    flask_app = Flask(
+    app = Flask(
         __name__,
         static_folder=os.path.join(project_root, 'static'),
         static_url_path='/static',
-        instance_relative_config=True
+        instance_relative_config=True,
     )
-    os.makedirs(flask_app.instance_path, exist_ok=True)
+    os.makedirs(app.instance_path, exist_ok=True)
 
-    flask_app.config['SQLALCHEMY_DATABASE_URI']        = os.getenv('DATABASE_URL')
-    flask_app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
-    flask_app.config['SECRET_KEY']                     = os.getenv('SECRET_KEY')
+    # Pick configuration
+    env = config_name or os.getenv('ENV') or os.getenv('FLASK_ENV') or 'production'
+    cfg_cls = DevConfig if env == 'development' else ProdConfig
+    app.config.from_object(cfg_cls)
 
-    db.init_app(flask_app)
-    migrate.init_app(flask_app, db)
+    # Initialise logging
+    logging.basicConfig(level=logging.DEBUG if app.debug else logging.INFO)
+
+    db.init_app(app)
+    migrate.init_app(app, db)
 
     # Ensure models loaded so tables can be created
     from app import models  # noqa
-    with flask_app.app_context():
+    with app.app_context():
         db.create_all()
 
-    @flask_app.route('/')
+    @app.route('/')
     def index():
         return redirect(url_for('estimates.list_estimates'))
 
-    from app.bundles.routes   import bp as bundles_bp
+    @app.errorhandler(404)
+    def not_found(_):
+        return render_template('errors/404.html'), 404
+
+    @app.errorhandler(500)
+    def server_error(_):
+        return render_template('errors/500.html'), 500
+
+    from app.bundles.routes import bp as bundles_bp
     from app.estimates.routes import bp as estimates_bp
 
-    flask_app.register_blueprint(bundles_bp,   url_prefix='/bundles')
-    flask_app.register_blueprint(estimates_bp, url_prefix='/estimates')
+    app.register_blueprint(bundles_bp, url_prefix='/bundles')
+    app.register_blueprint(estimates_bp, url_prefix='/estimates')
 
-    return flask_app
+    return app

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,17 @@
+import os
+
+class BaseConfig:
+    SECRET_KEY = os.getenv('SECRET_KEY', 'change-me')
+    SQLALCHEMY_DATABASE_URI = os.getenv('DATABASE_URL', 'sqlite:///app.db')
+    SQLALCHEMY_TRACK_MODIFICATIONS = False
+    SESSION_COOKIE_SAMESITE = 'Lax'
+    SESSION_COOKIE_SECURE = False
+
+class DevConfig(BaseConfig):
+    DEBUG = True
+    ENV = 'development'
+
+class ProdConfig(BaseConfig):
+    DEBUG = False
+    ENV = 'production'
+    SESSION_COOKIE_SECURE = True

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="utf-8">
   <title>{% block title %}Quoting Tool{% endblock %}</title>
+  <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0/dist/css/bootstrap.min.css" rel="stylesheet">
 </head>
 <body>
 <nav class="navbar navbar-expand bg-light mb-4">
@@ -19,7 +19,6 @@
   <div class="alert alert-{{ category }}">{{ message }}</div>
   {% endfor %}
   {% block content %}{% endblock %}
-</div>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0/dist/js/bootstrap.bundle.min.js"></script>
-</body>
-</html>
+ </div>
+ </body>
+ </html>

--- a/app/templates/errors/404.html
+++ b/app/templates/errors/404.html
@@ -1,0 +1,8 @@
+{% extends 'base.html' %}
+{% block title %}Not Found{% endblock %}
+{% block content %}
+<div class="text-center mt-8">
+  <h1 class="text-2xl mb-4">Page Not Found</h1>
+  <a class="bg-blue-500 text-white px-4 py-2 rounded" href="{{ url_for('estimates.list_estimates') }}">Back to Estimates</a>
+</div>
+{% endblock %}

--- a/app/templates/errors/500.html
+++ b/app/templates/errors/500.html
@@ -1,0 +1,8 @@
+{% extends 'base.html' %}
+{% block title %}Server Error{% endblock %}
+{% block content %}
+<div class="text-center mt-8">
+  <h1 class="text-2xl mb-4">Something went wrong</h1>
+  <a class="bg-blue-500 text-white px-4 py-2 rounded" href="{{ url_for('estimates.list_estimates') }}">Back to Estimates</a>
+</div>
+{% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,6 @@ Flask-SQLAlchemy
 python-dotenv
 requests
 gunicorn
+Flask-WTF
+ruff
+pytest

--- a/run.py
+++ b/run.py
@@ -1,8 +1,10 @@
+import os
 from app import create_app, db
 from flask_migrate import Migrate
 
 app = create_app()
 migrate = Migrate(app, db)
 
-if __name__ == '__main__':
-    app.run(host='0.0.0.0')
+if __name__ == "__main__":
+    port = int(os.getenv("PORT", "5000"))
+    app.run(host="0.0.0.0", port=port)

--- a/tests/test_bundle_copy.py
+++ b/tests/test_bundle_copy.py
@@ -1,0 +1,54 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from app import create_app, db
+from app.models import Bundle, BundleItem, Estimate, EstimateItem
+
+
+def setup_app():
+    os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
+    app = create_app('development')
+    app.config.update(SQLALCHEMY_DATABASE_URI='sqlite:///:memory:')
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+    return app
+
+
+def copy_bundle(bundle, estimate):
+    for bi in bundle.items:
+        ei = EstimateItem(
+            estimate_id=estimate.id,
+            type='product',
+            object_id=bi.id,
+            name=bi.product_name,
+            description=bi.description,
+            quantity=bi.quantity,
+            unit_price=bi.unit_price,
+            retail=bi.retail,
+        )
+        db.session.add(ei)
+    db.session.commit()
+
+
+def test_bundle_copy_is_snapshot():
+    app = setup_app()
+    with app.app_context():
+        b = Bundle(name='Starter', description='')
+        bi = BundleItem(bundle=b, product_name='Widget', description='',
+                        quantity=1, unit_price=10.0, retail=15.0)
+        db.session.add_all([b, bi])
+        db.session.commit()
+        est = Estimate(customer_id=None, customer_name='Cust', customer_address='')
+        db.session.add(est)
+        db.session.commit()
+        copy_bundle(b, est)
+        line = EstimateItem.query.filter_by(estimate_id=est.id).first()
+        assert line.unit_price == 10.0
+        # mutate bundle item after copying
+        bi.unit_price = 999.0
+        db.session.commit()
+        line_after = EstimateItem.query.filter_by(estimate_id=est.id).first()
+        assert line_after.unit_price == 10.0

--- a/tests/test_estimate_math.py
+++ b/tests/test_estimate_math.py
@@ -1,0 +1,43 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from app import create_app, db
+from app.models import Estimate, EstimateItem
+
+
+def setup_app():
+    os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
+    app = create_app('development')
+    app.config.update(SQLALCHEMY_DATABASE_URI='sqlite:///:memory:')
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+    return app
+
+
+def test_totals_and_markup():
+    app = setup_app()
+    with app.app_context():
+        est = Estimate(customer_id=None, customer_name='Test', customer_address='')
+        db.session.add(est)
+        db.session.commit()
+        i1 = EstimateItem(estimate_id=est.id, type='product', object_id=1,
+                          name='Widget', description='', quantity=2,
+                          unit_price=10.0, retail=15.0)
+        i2 = EstimateItem(estimate_id=est.id, type='product', object_id=2,
+                          name='Gadget', description='', quantity=1,
+                          unit_price=5.0, retail=8.0)
+        db.session.add_all([i1, i2])
+        db.session.commit()
+        assert est.total_cost == 2*10.0 + 1*5.0
+        assert est.total_retail == 2*15.0 + 1*8.0
+        profit = est.total_retail - est.total_cost
+        assert est.profit == profit
+        markup = (profit / est.total_cost) * 100
+        assert round(markup, 2) == round((profit / est.total_cost) * 100, 2)
+        db.session.delete(i1)
+        db.session.commit()
+        assert est.total_cost == 5.0
+        assert est.total_retail == 8.0


### PR DESCRIPTION
## Summary
- introduce environment-based configuration and error pages
- enable Tailwind styling and read port from environment
- add unit tests for estimate totals and bundle copy semantics

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b99f79c63c83309d8c078c9f589cc5