### PR TITLE
Restore Bootstrap styling for templates

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="utf-8">
   <title>{% block title %}Quoting Tool{% endblock %}</title>
-  <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0/dist/css/bootstrap.min.css" rel="stylesheet">
 </head>
 <body>
 <nav class="navbar navbar-expand bg-light mb-4">
@@ -20,5 +20,6 @@
   {% endfor %}
   {% block content %}{% endblock %}
  </div>
+ <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0/dist/js/bootstrap.bundle.min.js"></script>
  </body>
  </html>


### PR DESCRIPTION
## Summary
- Revert base template to use Bootstrap CDN instead of missing Tailwind script
- Include Bootstrap JavaScript bundle to enable navigation and component behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9ab481b648330b5761f0152e2729a