### PR TITLE
Limit product search and enhance bundle builder

### DIFF
--- a/app/api/repairshopr.py
+++ b/app/api/repairshopr.py
@@ -24,13 +24,11 @@ def get_products(query):
     seen_ids = set()
 
     # Try multiple search parameter variations.  The RepairShopr API supports
-    # searching by different fields depending on the parameter name.  We query
-    # several to cover common cases a user may type.
+    # searching by different fields depending on the parameter name.  To keep
+    # the search fast we limit lookups to name and SKU only.
     param_sets = [
-        {'query': query},        # generic search (usually name)
-        {'name': query},         # explicit name search
-        {'description': query},  # description search
-        {'sku': query},          # SKU lookup
+        {'name': query},  # explicit name search
+        {'sku': query},   # SKU lookup
     ]
 
     for params in param_sets:

--- a/app/bundles/routes.py
+++ b/app/bundles/routes.py
@@ -114,10 +114,11 @@ def remove_bundle_item(bundle_id, item_id):
 def update_bundle_item(bundle_id, item_id):
     data = request.get_json()
     it   = BundleItem.query.get_or_404(item_id)
-    it.quantity    = int(data.get('quantity', it.quantity))
-    it.unit_price        = float(data.get('cost', it.unit_price))
-    it.retail      = float(data.get('retail', it.retail))
-    it.description = data.get('description', it.description)
+    it.quantity     = int(data.get('quantity', it.quantity))
+    it.unit_price   = float(data.get('cost', it.unit_price))
+    it.retail       = float(data.get('retail', it.retail))
+    it.description  = data.get('description', it.description)
+    it.product_name = data.get('product_name', it.product_name)
     db.session.commit()
     return jsonify(success=True)
 

--- a/app/templates/bundles/edit.html
+++ b/app/templates/bundles/edit.html
@@ -61,24 +61,56 @@
                value="{{ "{:.2f}".format(item.retail) }}">
       </td>
       <td>
-        <button class="btn btn-sm btn-danger remove-item">Remove</button>
+        <button class="btn btn-sm btn-danger remove-item">&times;</button>
       </td>
     </tr>
     {% endfor %}
   </tbody>
 </table>
 
-<div class="mt-4">
-  <p><strong>Total Cost:</strong> $<span id="total-cost">{{ "{:.2f}".format(total_cost) }}</span></p>
-  <p><strong>Total Retail:</strong> $<span id="total-retail">{{ "{:.2f}".format(total_retail) }}</span></p>
-  <p><strong>Markup %:</strong> <span id="markup-percent">
-    {% if total_cost > 0 %}
-      {{ "{:.2f}".format((total_retail - total_cost) / total_cost * 100) }}%
-    {% else %}
-      0.00%
-    {% endif %}
-  </span></p>
-  <p><strong>Profit:</strong> $<span id="profit-amount">{{ "{:.2f}".format(total_retail - total_cost) }}</span></p>
+<div class="row mt-4" id="bundle-summary">
+  <div class="col-md mb-2">
+    <div class="border rounded p-2 text-center bg-light">
+      <div class="fw-bold">Total Cost</div>
+      <div>$<span id="total-cost">{{ "{:.2f}".format(total_cost) }}</span></div>
+    </div>
+  </div>
+  <div class="col-md mb-2">
+    <div class="border rounded p-2 text-center bg-light">
+      <div class="fw-bold">Total Retail</div>
+      <div>$<span id="total-retail">{{ "{:.2f}".format(total_retail) }}</span></div>
+    </div>
+  </div>
+  <div class="col-md mb-2">
+    <div class="border rounded p-2 text-center bg-light">
+      <div class="fw-bold">Profit</div>
+      <div>$<span id="profit-amount">{{ "{:.2f}".format(total_retail - total_cost) }}</span></div>
+    </div>
+  </div>
+  <div class="col-md mb-2">
+    <div class="border rounded p-2 text-center bg-light">
+      <div class="fw-bold">Margin</div>
+      <div><span id="margin-percent">
+        {% if total_retail > 0 %}
+          {{ "{:.2f}".format((total_retail - total_cost) / total_retail * 100) }}%
+        {% else %}
+          0.00%
+        {% endif %}
+      </span></div>
+    </div>
+  </div>
+  <div class="col-md mb-2">
+    <div class="border rounded p-2 text-center bg-light">
+      <div class="fw-bold">Markup</div>
+      <div><span id="markup-percent">
+        {% if total_cost > 0 %}
+          {{ "{:.2f}".format((total_retail - total_cost) / total_cost * 100) }}%
+        {% else %}
+          0.00%
+        {% endif %}
+      </span></div>
+    </div>
+  </div>
 </div>
 
 <script>

--- a/app/templates/estimates/view.html
+++ b/app/templates/estimates/view.html
@@ -17,7 +17,7 @@
       <td><input type="number" value="{{ i.quantity }}" data-field="quantity"></td>
       <td><input type="text"   value="{{ i.unit_price }}" data-field="unit_price"></td>
       <td><input type="text"   value="{{ i.notes }}"      data-field="notes"></td>
-      <td><button class="btn btn-sm btn-danger remove-item">Remove</button></td>
+      <td><button class="btn btn-sm btn-danger remove-item">&times;</button></td>
     </tr>
     {% endfor %}
   </tbody>

--- a/static/js/estimates.js
+++ b/static/js/estimates.js
@@ -232,6 +232,7 @@ bsSug.addEventListener('click', async e => {
   const body = document.getElementById('items-body');
   body.addEventListener('click', async e => {
     if (e.target.matches('.remove-item')) {
+      if (!confirm('Remove this item?')) return;
       const row = e.target.closest('tr');
       await fetch(`/estimates/${estId}/remove-item/${row.dataset.itemId}`, { method: 'POST' });
       row.remove();

--- a/tests/test_bundle_product_search.py
+++ b/tests/test_bundle_product_search.py
@@ -35,7 +35,7 @@ def make_fake_get(responses):
 
 def test_search_by_name(monkeypatch):
     responses = {
-        'query': {
+        'name': {
             'Widget': {
                 'products': [
                     {
@@ -57,7 +57,8 @@ def test_search_by_name(monkeypatch):
     assert prods[0]['retail'] == 2.0
 
 
-def test_search_by_description(monkeypatch):
+def test_description_not_searched(monkeypatch):
+    """Description-only matches should not return results."""
     responses = {
         'description': {
             'amazing': {
@@ -75,10 +76,7 @@ def test_search_by_description(monkeypatch):
     }
     monkeypatch.setattr(repairshopr.requests, 'get', make_fake_get(responses))
     prods = search_products('amazing')
-    assert len(prods) == 1
-    assert prods[0]['id'] == 2
-    assert prods[0]['cost'] == 3.0
-    assert prods[0]['retail'] == 5.0
+    assert prods == []
 
 
 def test_search_by_sku(monkeypatch):


### PR DESCRIPTION
## Summary
- Search RepairShopr products only by name and SKU to speed up lookups
- Add confirmation dialogs and X buttons for item removal
- Live-update bundle items and totals with improved summary including profit, margin, and markup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b9b98a2454833092f6f8190e763984