### PR TITLE
feat: add admin link and test

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -12,6 +12,7 @@
   <div class="navbar-nav">
     <a class="nav-link" href="{{ url_for('bundles.list_bundles') }}">Bundles</a>
     <a class="nav-link" href="{{ url_for('estimates.list_estimates') }}">Estimates</a>
+    <a class="nav-link" href="{{ url_for('admin.inventory_page') }}">Admin</a>
   </div>
 </nav>
 <div class="container">

--- a/tests/test_admin_nav.py
+++ b/tests/test_admin_nav.py
@@ -1,0 +1,23 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from app import create_app
+from app.inventory_store import init_db
+
+
+def make_app(tmp_path):
+    os.environ.setdefault('REPAIRSHOPR_SUBDOMAIN', 'test')
+    os.environ.setdefault('REPAIRSHOPR_API_KEY', 'key')
+    app = create_app('development')
+    app.instance_path = str(tmp_path)
+    os.makedirs(app.instance_path, exist_ok=True)
+    with app.app_context():
+        init_db()
+    return app
+
+
+def test_admin_link_in_nav(tmp_path):
+    app = make_app(tmp_path)
+    client = app.test_client()
+    res = client.get('/bundles/')
+    assert b'/admin/inventory' in res.data


### PR DESCRIPTION
## Summary
- link admin inventory page in navbar
- cover navigation link with test

## Testing
- `ruff check .`
- `pytest -q`
- `make lint` *(fails: missing separator)*
- `make test` *(fails: missing separator)*

------
https://chatgpt.com/codex/tasks/task_e_68b9c6c576c88330b8dd90d322dc450e