### PR TITLE
feat: expose inventory db via admin

### DIFF
--- a/app/admin.py
+++ b/app/admin.py
@@ -5,7 +5,7 @@ import os
 import threading
 from flask import Blueprint, jsonify, render_template, request, abort, current_app
 
-from .inventory_store import get_meta
+from .inventory_store import get_meta, list_products
 from .inventory_sync import full_sync
 
 bp = Blueprint('admin', __name__, template_folder='templates/admin')
@@ -55,3 +55,10 @@ def inventory_sync():
 def inventory_status():
     last = get_meta('inventory_last_synced_at')
     return jsonify(last_synced_at=last, running=_sync_running)
+
+
+@bp.route('/inventory/products')
+def inventory_products():
+    """Expose a subset of the mirrored products for admin inspection."""
+    prods = list_products()
+    return jsonify(products=prods)

--- a/app/templates/admin/inventory.html
+++ b/app/templates/admin/inventory.html
@@ -4,10 +4,16 @@
 <p>Last DB Pull: <span id="last-sync">{{ last }}</span></p>
 <button id="sync-btn" class="btn btn-primary">Run manual update</button>
 <div id="status" class="mt-2"></div>
+
+<table class="table mt-4">
+  <thead><tr><th>ID</th><th>Name</th><th>Qty</th></tr></thead>
+  <tbody id="prod-body"></tbody>
+</table>
 <script>
 const SECRET = '{{ secret }}';
 const btn = document.getElementById('sync-btn');
 const statusEl = document.getElementById('status');
+const prodBody = document.getElementById('prod-body');
 async function check() {
   const res = await fetch('/admin/inventory/status', {headers:{'X-Admin-Secret':SECRET}});
   const data = await res.json();
@@ -19,6 +25,7 @@ async function check() {
   } else {
     statusEl.textContent = '';
     btn.disabled = false;
+    loadProducts();
   }
 }
 btn.addEventListener('click', async () => {
@@ -26,6 +33,12 @@ btn.addEventListener('click', async () => {
   await fetch('/admin/inventory/sync', {method:'POST', headers:{'X-Admin-Secret':SECRET}});
   check();
 });
+async function loadProducts(){
+  const res = await fetch('/admin/inventory/products', {headers:{'X-Admin-Secret':SECRET}});
+  const data = await res.json();
+  prodBody.innerHTML = data.products.map(p=>`<tr><td>${p.id}</td><td>${p.name}</td><td>${p.quantity}</td></tr>`).join('');
+}
 check();
+loadProducts();
 </script>
 {% endblock %}

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -112,3 +112,21 @@ def test_admin_sync(monkeypatch, tmp_path):
         time.sleep(0.1)
     assert status['running'] is False
     assert status['last_synced_at'] == 'now'
+
+
+def test_admin_inventory_products(tmp_path):
+    app = make_app(tmp_path)
+    with app.app_context():
+        upsert_products([
+            {
+                'id': 1,
+                'name': 'Gizmo',
+                'price_retail': 1,
+                'price_cost': 0,
+                'quantity': 7,
+            }
+        ])
+    client = app.test_client()
+    res = client.get('/admin/inventory/products', headers={'X-Admin-Secret': 's3cr3t'})
+    data = res.get_json()
+    assert data['products'][0]['quantity'] == 7


### PR DESCRIPTION
## Summary
- expose subset of mirrored products via `/admin/inventory/products`
- show product table with quantities on admin inventory page
- add list_products helper to inventory store
- test admin endpoint returns quantity info

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9d6f54aac8330b6cdac2326851ba0