### PR TITLE
Enhance admin inventory page with CSV export and status

### DIFF
--- a/app/templates/admin/inventory.html
+++ b/app/templates/admin/inventory.html
@@ -3,6 +3,7 @@
 <h1>Inventory Mirror</h1>
 <p>Last DB Pull: <span id="last-sync">{{ last }}</span></p>
 <button id="sync-btn" class="btn btn-primary">Run manual update</button>
+<button id="csv-btn" class="btn btn-secondary ms-2">Open DB CSV</button>
 <div id="status" class="mt-2"></div>
 
 <table class="table mt-4">
@@ -12,6 +13,7 @@
 <script>
 const SECRET = '{{ secret }}';
 const btn = document.getElementById('sync-btn');
+const csvBtn = document.getElementById('csv-btn');
 const statusEl = document.getElementById('status');
 const prodBody = document.getElementById('prod-body');
 async function check() {
@@ -19,11 +21,11 @@ async function check() {
   const data = await res.json();
   document.getElementById('last-sync').textContent = data.last_synced_at || 'never';
   if (data.running) {
-    statusEl.textContent = 'Sync running...';
+    statusEl.textContent = 'Getting information from RepairShopr...';
     btn.disabled = true;
     setTimeout(check, 3000);
   } else {
-    statusEl.textContent = '';
+    statusEl.textContent = 'Finished fetching.';
     btn.disabled = false;
     loadProducts();
   }
@@ -32,6 +34,12 @@ btn.addEventListener('click', async () => {
   btn.disabled = true;
   await fetch('/admin/inventory/sync', {method:'POST', headers:{'X-Admin-Secret':SECRET}});
   check();
+});
+csvBtn.addEventListener('click', async () => {
+  const res = await fetch('/admin/inventory/products.csv', {headers:{'X-Admin-Secret':SECRET}});
+  const blob = await res.blob();
+  const url = URL.createObjectURL(blob);
+  window.open(url, '_blank');
 });
 async function loadProducts(){
   const res = await fetch('/admin/inventory/products', {headers:{'X-Admin-Secret':SECRET}});


### PR DESCRIPTION
## Summary
- Add CSV download route for mirrored inventory and button on admin page to open it.
- Display live sync status indicating when RepairShopr data is being fetched and when finished.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9da7228408330862d27568cd41e3a