### PR TITLE
Improve RepairShopr inventory sync

### DIFF
--- a/app/admin.py
+++ b/app/admin.py
@@ -16,15 +16,12 @@ from flask import (
     make_response,
 )
 
-from .inventory_store import get_meta, list_products, ro_conn
+from .inventory_store import get_meta, list_products, ro_conn, set_meta
 from .inventory_sync import full_sync
 
 bp = Blueprint('admin', __name__, template_folder='templates/admin')
 
 ADMIN_SECRET = os.environ.get('ADMIN_SECRET')
-_sync_running = False
-
-
 def _check_secret():
     if ADMIN_SECRET and request.headers.get('X-Admin-Secret') != ADMIN_SECRET:
         abort(403)
@@ -38,34 +35,35 @@ def before():
 @bp.route('/inventory')
 def inventory_page():
     last = get_meta('inventory_last_synced_at', 'never')
-    return render_template('admin/inventory.html', last=last, secret=ADMIN_SECRET or '')
+    count = get_meta('inventory_last_synced_count', '0')
+    return render_template('admin/inventory.html', last=last, count=count, secret=ADMIN_SECRET or '')
 
 
 @bp.route('/inventory/sync', methods=['POST'])
 def inventory_sync():
-    global _sync_running
-    if _sync_running:
+    if get_meta('inventory_sync_running') == '1':
         return jsonify(started=False), 409
+
+    set_meta('inventory_sync_running', '1')
 
     app = current_app._get_current_object()
 
     def runner():
-        global _sync_running
-        _sync_running = True
-        try:
-            with app.app_context():
-                full_sync()
-        finally:
-            _sync_running = False
+        with app.app_context():
+            full_sync()
 
-    threading.Thread(target=runner, daemon=True).start()
+    threading.Thread(target=runner).start()
     return jsonify(started=True)
 
 
 @bp.route('/inventory/status')
 def inventory_status():
-    last = get_meta('inventory_last_synced_at')
-    return jsonify(last_synced_at=last, running=_sync_running)
+    return jsonify(
+        running=get_meta('inventory_sync_running', '0'),
+        last_synced_at=get_meta('inventory_last_synced_at'),
+        last_synced_count=get_meta('inventory_last_synced_count'),
+        last_error=get_meta('inventory_last_error'),
+    )
 
 
 @bp.route('/inventory/products')

--- a/app/templates/admin/inventory.html
+++ b/app/templates/admin/inventory.html
@@ -1,8 +1,8 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>Inventory Mirror</h1>
-<p>Last DB Pull: <span id="last-sync">{{ last }}</span></p>
-<button id="sync-btn" class="btn btn-primary">Run manual update</button>
+<p>Last DB Pull: <span id="last-sync">{{ last }}</span> (<span id="last-count">{{ count }}</span> items)</p>
+<button id="sync-btn" class="btn btn-primary">Update now</button>
 <button id="csv-btn" class="btn btn-secondary ms-2">Open DB CSV</button>
 <div id="status" class="mt-2"></div>
 
@@ -20,13 +20,18 @@ async function check() {
   const res = await fetch('/admin/inventory/status', {headers:{'X-Admin-Secret':SECRET}});
   const data = await res.json();
   document.getElementById('last-sync').textContent = data.last_synced_at || 'never';
-  if (data.running) {
+  document.getElementById('last-count').textContent = data.last_synced_count || '0';
+  if (data.running === "1") {
     statusEl.textContent = 'Getting information from RepairShopr...';
     btn.disabled = true;
     setTimeout(check, 3000);
   } else {
-    statusEl.textContent = 'Finished fetching.';
     btn.disabled = false;
+    if (data.last_error) {
+      statusEl.textContent = data.last_error;
+    } else {
+      statusEl.textContent = 'Finished fetching.';
+    }
     loadProducts();
   }
 }


### PR DESCRIPTION
## Summary
- Streamline RepairShopr product sync using length-based pagination and token-bucket rate limiting with retries
- Track sync progress in meta table and expose running/count/error in admin endpoints and UI
- Add tests for pagination boundaries and retry/backoff behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9de8a0d9083308d2f0f6037b48427