### PR TITLE
Refine admin inventory sync and status

### DIFF
--- a/app/admin.py
+++ b/app/admin.py
@@ -16,7 +16,7 @@ from flask import (
     make_response,
 )
 
-from .inventory_store import get_meta, list_products, ro_conn, set_meta
+from .inventory_store import get_meta, ro_conn, set_meta
 from .inventory_sync import full_sync
 
 bp = Blueprint('admin', __name__, template_folder='templates/admin')
@@ -63,14 +63,8 @@ def inventory_status():
         last_synced_at=get_meta('inventory_last_synced_at'),
         last_synced_count=get_meta('inventory_last_synced_count'),
         last_error=get_meta('inventory_last_error'),
+        state=get_meta('inventory_sync_status', 'idle'),
     )
-
-
-@bp.route('/inventory/products')
-def inventory_products():
-    """Expose a subset of the mirrored products for admin inspection."""
-    prods = list_products()
-    return jsonify(products=prods)
 
 
 @bp.route('/inventory/products.csv')

--- a/app/templates/admin/inventory.html
+++ b/app/templates/admin/inventory.html
@@ -5,34 +5,33 @@
 <button id="sync-btn" class="btn btn-primary">Update now</button>
 <button id="csv-btn" class="btn btn-secondary ms-2">Open DB CSV</button>
 <div id="status" class="mt-2"></div>
-
-<table class="table mt-4">
-  <thead><tr><th>ID</th><th>Name</th><th>Qty</th></tr></thead>
-  <tbody id="prod-body"></tbody>
-</table>
 <script>
 const SECRET = '{{ secret }}';
 const btn = document.getElementById('sync-btn');
 const csvBtn = document.getElementById('csv-btn');
 const statusEl = document.getElementById('status');
-const prodBody = document.getElementById('prod-body');
 async function check() {
   const res = await fetch('/admin/inventory/status', {headers:{'X-Admin-Secret':SECRET}});
   const data = await res.json();
   document.getElementById('last-sync').textContent = data.last_synced_at || 'never';
   document.getElementById('last-count').textContent = data.last_synced_count || '0';
   if (data.running === "1") {
-    statusEl.textContent = 'Getting information from RepairShopr...';
+    if (data.state === 'waiting') {
+      statusEl.textContent = 'Waiting for rate limit...';
+    } else {
+      statusEl.textContent = 'Getting information from RepairShopr...';
+    }
     btn.disabled = true;
     setTimeout(check, 3000);
   } else {
     btn.disabled = false;
     if (data.last_error) {
       statusEl.textContent = data.last_error;
-    } else {
+    } else if (data.state === 'completed') {
       statusEl.textContent = 'Finished fetching.';
+    } else {
+      statusEl.textContent = '';
     }
-    loadProducts();
   }
 }
 btn.addEventListener('click', async () => {
@@ -46,12 +45,6 @@ csvBtn.addEventListener('click', async () => {
   const url = URL.createObjectURL(blob);
   window.open(url, '_blank');
 });
-async function loadProducts(){
-  const res = await fetch('/admin/inventory/products', {headers:{'X-Admin-Secret':SECRET}});
-  const data = await res.json();
-  prodBody.innerHTML = data.products.map(p=>`<tr><td>${p.id}</td><td>${p.name}</td><td>${p.quantity}</td></tr>`).join('');
-}
 check();
-loadProducts();
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Drop database table from admin inventory page and show live sync state
- Batch inventory sync requests and expose status via API

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9e1946d8c83308f4278be80bebfb6