### PR TITLE
Improve RepairShopr inventory syncing and rate limiting

### DIFF
--- a/app/bundles/utils.py
+++ b/app/bundles/utils.py
@@ -1,14 +1,18 @@
 # app/bundles/utils.py
 from app.inventory_store import search_products as _search_products
-from app import inventory_sync
+from app.repairshopr_client import (
+    fetch_by_barcode,
+    fetch_by_sku,
+    fetch_by_query,
+)
 
 
 class RemoteFetch:
     """Adapter exposing network fetch helpers."""
 
-    by_barcode = staticmethod(inventory_sync.fetch_product_by_barcode)
-    by_sku = staticmethod(inventory_sync.fetch_products_by_sku)
-    by_query = staticmethod(inventory_sync.fetch_products_query)
+    by_barcode = staticmethod(fetch_by_barcode)
+    by_sku = staticmethod(fetch_by_sku)
+    by_query = staticmethod(fetch_by_query)
 
 
 def search_products(q: str, page: int = 1) -> list:

--- a/app/estimates/utils.py
+++ b/app/estimates/utils.py
@@ -1,15 +1,19 @@
 # app/estimates/utils.py
 
 from app.inventory_store import search_products as _search_products
-from app import inventory_sync
+from app.repairshopr_client import (
+    fetch_by_barcode,
+    fetch_by_sku,
+    fetch_by_query,
+)
 from app.api.repairshopr import search_customers
 from app.models import Bundle, EstimateItem
 
 
 class RemoteFetch:
-    by_barcode = staticmethod(inventory_sync.fetch_product_by_barcode)
-    by_sku = staticmethod(inventory_sync.fetch_products_by_sku)
-    by_query = staticmethod(inventory_sync.fetch_products_query)
+    by_barcode = staticmethod(fetch_by_barcode)
+    by_sku = staticmethod(fetch_by_sku)
+    by_query = staticmethod(fetch_by_query)
 
 
 def search_products(q: str, page: int = 1) -> list:

--- a/app/repairshopr_client.py
+++ b/app/repairshopr_client.py
@@ -1,0 +1,91 @@
+"""HTTP client for RepairShopr API with global rate limiter."""
+
+from __future__ import annotations
+
+import os
+import random
+import threading
+import time
+from typing import List, Dict
+
+import requests
+
+SUBDOMAIN = os.environ["REPAIRSHOPR_SUBDOMAIN"]
+API_KEY = os.environ["REPAIRSHOPR_API_KEY"]
+API_BASE = f"https://{SUBDOMAIN}.repairshopr.com/api/v1"
+
+
+class TokenBucket:
+    def __init__(self, capacity: int = 120, refill_per_min: int = 120) -> None:
+        self.capacity = capacity
+        self.tokens = capacity
+        self.refill_rate = refill_per_min / 60.0
+        self.last = time.monotonic()
+        self.lock = threading.Lock()
+
+    def acquire(self) -> None:
+        with self.lock:
+            now = time.monotonic()
+            self.tokens = min(
+                self.capacity, self.tokens + (now - self.last) * self.refill_rate
+            )
+            self.last = now
+            if self.tokens >= 1:
+                self.tokens -= 1
+                return
+        # sleep outside the lock to avoid blocking producers
+        time.sleep(0.55 + random.random() * 0.05)
+
+
+bucket = TokenBucket(capacity=120, refill_per_min=120)
+
+
+def session() -> requests.Session:
+    s = requests.Session()
+    s.headers.update(
+        {"Authorization": f"Bearer {API_KEY}", "Accept": "application/json"}
+    )
+    return s
+
+
+def get_with_retries(url: str, params: dict | None = None) -> requests.Response:
+    tries, backoff = 0, 0.5
+    while True:
+        bucket.acquire()
+        r = session().get(url, params=params, timeout=(5, 15))
+        if r.status_code < 500 and r.status_code != 429:
+            r.raise_for_status()
+            return r
+        tries += 1
+        if tries >= 3:
+            r.raise_for_status()
+        time.sleep(backoff + random.random() * 0.2)
+        backoff = min(backoff * 2, 10.0)
+
+
+def fetch_products_page(page: int, sort: str = "id ASC") -> List[Dict]:
+    r = get_with_retries(f"{API_BASE}/products", params={"page": page, "sort": sort})
+    data = r.json()
+    return data.get("products") or data.get("data") or []
+
+
+def fetch_by_barcode(barcode: str) -> Dict | None:
+    r = get_with_retries(
+        f"{API_BASE}/products/barcode", params={"barcode": barcode}
+    )
+    data = r.json()
+    return data.get("product") or data
+
+
+def fetch_by_sku(sku: str) -> List[Dict]:
+    r = get_with_retries(f"{API_BASE}/products", params={"sku": sku, "page": 1})
+    data = r.json()
+    return data.get("products") or data.get("data") or []
+
+
+def fetch_by_query(query: str) -> List[Dict]:
+    r = get_with_retries(f"{API_BASE}/products", params={"query": query, "page": 1})
+    data = r.json()
+    return data.get("products") or data.get("data") or []
+
+

--- a/app/templates/admin/inventory.html
+++ b/app/templates/admin/inventory.html
@@ -1,50 +1,61 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>Inventory Mirror</h1>
-<p>Last DB Pull: <span id="last-sync">{{ last }}</span> (<span id="last-count">{{ count }}</span> items)</p>
-<button id="sync-btn" class="btn btn-primary">Update now</button>
-<button id="csv-btn" class="btn btn-secondary ms-2">Open DB CSV</button>
+<p>Last full sync: <span id="last-full">{{ last_full }}</span></p>
+<p>Last quick check: <span id="last-quick">{{ last_quick }}</span></p>
+<p>Max product id: <span id="max-id">{{ max_id }}</span></p>
+<button id="quick-btn" class="btn btn-primary me-2">Quick Update</button>
+<button id="full-btn" class="btn btn-danger me-2">Full Refresh</button>
+<button id="csv-btn" class="btn btn-secondary">Open DB CSV</button>
 <div id="status" class="mt-2"></div>
 <script>
 const SECRET = '{{ secret }}';
-const btn = document.getElementById('sync-btn');
+const quickBtn = document.getElementById('quick-btn');
+const fullBtn = document.getElementById('full-btn');
 const csvBtn = document.getElementById('csv-btn');
 const statusEl = document.getElementById('status');
-async function check() {
+
+async function poll() {
   const res = await fetch('/admin/inventory/status', {headers:{'X-Admin-Secret':SECRET}});
   const data = await res.json();
-  document.getElementById('last-sync').textContent = data.last_synced_at || 'never';
-  document.getElementById('last-count').textContent = data.last_synced_count || '0';
-  if (data.running === "1") {
-    if (data.state === 'waiting') {
-      statusEl.textContent = 'Waiting for rate limit...';
-    } else {
-      statusEl.textContent = 'Getting information from RepairShopr...';
-    }
-    btn.disabled = true;
-    setTimeout(check, 3000);
+  document.getElementById('last-full').textContent = data.last_full_sync_at || 'never';
+  document.getElementById('last-quick').textContent = data.last_quick_check_at || 'never';
+  document.getElementById('max-id').textContent = data.max_product_id_seen || 0;
+  if (data.running) {
+    statusEl.textContent = 'Sync in progress...';
+    quickBtn.disabled = fullBtn.disabled = true;
+    setTimeout(poll, 3000);
   } else {
-    btn.disabled = false;
+    quickBtn.disabled = fullBtn.disabled = false;
     if (data.last_error) {
       statusEl.textContent = data.last_error;
-    } else if (data.state === 'completed') {
-      statusEl.textContent = 'Finished fetching.';
+    } else if (data.last_job_result) {
+      statusEl.textContent = JSON.stringify(data.last_job_result);
     } else {
       statusEl.textContent = '';
     }
   }
 }
-btn.addEventListener('click', async () => {
-  btn.disabled = true;
-  await fetch('/admin/inventory/sync', {method:'POST', headers:{'X-Admin-Secret':SECRET}});
-  check();
+
+quickBtn.addEventListener('click', async () => {
+  quickBtn.disabled = true;
+  await fetch('/admin/inventory/quick', {method:'POST', headers:{'X-Admin-Secret':SECRET}});
+  poll();
 });
+
+fullBtn.addEventListener('click', async () => {
+  fullBtn.disabled = true;
+  await fetch('/admin/inventory/full', {method:'POST', headers:{'X-Admin-Secret':SECRET}});
+  poll();
+});
+
 csvBtn.addEventListener('click', async () => {
   const res = await fetch('/admin/inventory/products.csv', {headers:{'X-Admin-Secret':SECRET}});
   const blob = await res.blob();
   const url = URL.createObjectURL(blob);
   window.open(url, '_blank');
 });
-check();
+
+poll();
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Add dedicated RepairShopr API client with global token bucket limiter
- Rework inventory mirror to store checksums and sync state
- Implement full and delta sync flows with admin endpoints and UI

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9e44722a48330a74eec9ff2f2a7de