### PR TITLE
Handle missing disabled column

### DIFF
--- a/app/inventory_store.py
+++ b/app/inventory_store.py
@@ -78,6 +78,12 @@ def init_db() -> None:
         )
         """
     )
+    # Existing installations may lack newer columns; ensure ``disabled`` exists
+    cols = [r[1] for r in c.execute("PRAGMA table_info(products)")]
+    if "disabled" not in cols:
+        # Add column with default 0 so existing rows are treated as enabled
+        c.execute("ALTER TABLE products ADD COLUMN disabled INTEGER DEFAULT 0")
+
     c.execute("CREATE INDEX IF NOT EXISTS idx_products_sku ON products(sku)")
     c.execute("CREATE INDEX IF NOT EXISTS idx_products_upc ON products(upc_code)")
     c.execute("CREATE INDEX IF NOT EXISTS idx_products_name ON products(name)")


### PR DESCRIPTION
## Summary
- ensure `disabled` column exists for existing product databases
- add database migration logic to avoid missing column errors during startup

## Testing
- `pytest -q`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b9ee319b608330bdb53b25bbf64163