### PR TITLE
Ensure products table has checksum column

### DIFF
--- a/app/inventory_store.py
+++ b/app/inventory_store.py
@@ -85,6 +85,8 @@ def init_db() -> None:
     if "disabled" not in cols:
         # Add column with default 0 so existing rows are treated as enabled
         c.execute("ALTER TABLE products ADD COLUMN disabled INTEGER DEFAULT 0")
+    if "checksum" not in cols:
+        c.execute("ALTER TABLE products ADD COLUMN checksum TEXT")
 
     c.execute("CREATE INDEX IF NOT EXISTS idx_products_sku ON products(sku)")
     c.execute("CREATE INDEX IF NOT EXISTS idx_products_upc ON products(upc_code)")

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -216,3 +216,35 @@ def test_init_db_adds_last_seen_at(tmp_path):
     conn.close()
     assert 'last_seen_at' in cols
 
+
+def test_init_db_adds_checksum(tmp_path):
+    app = create_app('development')
+    app.instance_path = str(tmp_path)
+    os.makedirs(app.instance_path, exist_ok=True)
+    db_path = os.path.join(app.instance_path, 'inventory.db')
+    conn = sqlite3.connect(db_path)
+    c = conn.cursor()
+    c.execute(
+        """
+        CREATE TABLE products (
+            id INTEGER PRIMARY KEY,
+            name TEXT,
+            sku TEXT,
+            upc_code TEXT,
+            category_id INTEGER,
+            price_cents INTEGER,
+            disabled INTEGER,
+            last_seen_at TEXT,
+            raw_json TEXT
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+    with app.app_context():
+        init_db()
+    conn = sqlite3.connect(db_path)
+    cols = [r[1] for r in conn.execute("PRAGMA table_info(products)")]
+    conn.close()
+    assert 'checksum' in cols
+


### PR DESCRIPTION
## Summary
- add missing checksum column migration in inventory DB init
- test that `init_db` adds checksum column when absent

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b9f22d1d6483309cd82c92ae0a304d