### PR TITLE
Add RepairShopr full export with rate limiting and CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__/
 instance/
 .env
 migrations/
+exports/

--- a/README.txt
+++ b/README.txt
@@ -1,0 +1,23 @@
+# Bundles App
+
+## RepairShopr Export
+
+The app includes a CLI to export data from RepairShopr.
+
+### Full export
+
+```
+flask rs-export full
+```
+
+Results are written as newline-delimited JSON files in the directory given by `EXPORT_DIR` (default `./exports`). A checkpoint file tracks progress so rerunning the command resumes where it left off.
+
+Use `--include-serials` to fetch product serial numbers in a second phase at a lower rate.
+
+### Database upsert
+
+Set `REPAIRSHOPR_EXPORT_TO_DB=true` to upsert records into the SQL database using minimal tables defined in `app.models`.
+
+### Incremental follow-up
+
+Tickets and invoices automatically use the last `updated_at` value seen in prior runs as a `since_updated_at` cursor, allowing incremental exports.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -58,9 +58,11 @@ def create_app(config_name: str | None = None) -> Flask:
     from app.bundles.routes import bp as bundles_bp
     from app.estimates.routes import bp as estimates_bp
     from app.admin import bp as admin_bp
+    from app.integrations.repairshopr_export import rs_export_cli
 
     app.register_blueprint(bundles_bp, url_prefix='/bundles')
     app.register_blueprint(estimates_bp, url_prefix='/estimates')
     app.register_blueprint(admin_bp, url_prefix='/admin')
+    app.cli.add_command(rs_export_cli)
 
     return app

--- a/app/integrations/repairshopr_export.py
+++ b/app/integrations/repairshopr_export.py
@@ -1,0 +1,313 @@
+import json
+import logging
+import os
+import random
+import threading
+import time
+from collections import deque
+from pathlib import Path
+from typing import Any, Dict, Generator, Iterable, Optional, Tuple
+
+import click
+import requests
+from flask import current_app
+
+from app import db
+
+# Configuration
+MAX_RPM = int(os.getenv("MAX_RPM", "120"))
+EXPORT_DIR = os.getenv("EXPORT_DIR", "./exports")
+SUBDOMAIN = os.getenv("REPAIRSHOPR_SUBDOMAIN", "")
+API_KEY = os.getenv("REPAIRSHOPR_API_KEY", "")
+BASE_URL = f"https://{SUBDOMAIN}.repairshopr.com/api/v1"
+
+
+class TokenBucket:
+    """Simple token bucket limiter shared across the process."""
+
+    def __init__(self, capacity: int = MAX_RPM, refill_per_min: int = MAX_RPM) -> None:
+        self.capacity = capacity
+        self.tokens = capacity
+        self.refill_rate = refill_per_min / 60.0
+        self.last = time.monotonic()
+        self.lock = threading.Lock()
+
+    def acquire(self, tokens: int = 1) -> None:
+        while True:
+            with self.lock:
+                now = time.monotonic()
+                self.tokens = min(
+                    self.capacity,
+                    self.tokens + (now - self.last) * self.refill_rate,
+                )
+                self.last = now
+                if self.tokens >= tokens:
+                    self.tokens -= tokens
+                    return
+                needed = (tokens - self.tokens) / self.refill_rate
+            time.sleep(max(needed, 0.01))
+
+
+bucket = TokenBucket()
+
+
+class RepairShoprClient:
+    def __init__(self, base_url: str = BASE_URL, api_key: str = API_KEY, timeout: int = 10) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.timeout = timeout
+        self.session = requests.Session()
+        self.session.headers.update(
+            {"Authorization": f"Bearer {api_key}", "Accept": "application/json"}
+        )
+        self.req_times: deque[float] = deque()
+
+    def _record_request(self) -> None:
+        now = time.monotonic()
+        self.req_times.append(now)
+        while self.req_times and self.req_times[0] < now - 60:
+            self.req_times.popleft()
+
+    def current_rpm(self) -> float:
+        self._record_request()  # prune old
+        return float(len(self.req_times))
+
+    def get(self, path: str, params: Optional[Dict[str, Any]] = None, tokens: int = 1) -> Dict[str, Any]:
+        url = f"{self.base_url}{path}"
+        tries = 0
+        while True:
+            bucket.acquire(tokens)
+            try:
+                r = self.session.get(url, params=params, timeout=self.timeout)
+            except requests.RequestException as e:  # network issue
+                tries += 1
+                if tries > 3:
+                    raise
+                delay = min(2 ** tries, 30) + random.random()
+                time.sleep(delay)
+                continue
+            if r.status_code == 429 or r.status_code >= 500:
+                tries += 1
+                if tries > 3:
+                    r.raise_for_status()
+                delay = min(2 ** tries, 30) + random.random()
+                time.sleep(delay)
+                continue
+            r.raise_for_status()
+            self._record_request()
+            return r.json()
+
+    def paginate(
+        self,
+        path: str,
+        params: Optional[Dict[str, Any]] = None,
+        start_page: int = 1,
+        tokens: int = 1,
+    ) -> Generator[Tuple[int, Iterable[Dict[str, Any]]], None, None]:
+        page = start_page
+        while True:
+            q = dict(params or {})
+            q["page"] = page
+            data = self.get(path, params=q, tokens=tokens)
+            payload: Iterable[Dict[str, Any]] = []
+            for v in data.values():
+                if isinstance(v, list):
+                    payload = v
+                    break
+            if not payload:
+                break
+            yield page, payload
+            meta = data.get("meta") or {}
+            total_pages = meta.get("total_pages")
+            if total_pages and page >= total_pages:
+                break
+            page += 1
+
+
+class CheckpointStore:
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        if path.exists():
+            self.data = json.loads(path.read_text())
+        else:
+            self.data = {}
+
+    def get(self, stream: str) -> Dict[str, Any]:
+        return self.data.get(stream, {})
+
+    def save(self, stream: str, page: int, cursor: Optional[str] = None) -> None:
+        self.data[stream] = {"page": page}
+        if cursor is not None:
+            self.data[stream]["cursor"] = cursor
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.path.write_text(json.dumps(self.data, indent=2))
+
+
+# Mapping stream -> (path, params, cursor_field)
+STREAMS = [
+    ("customers", "/customers", {}, None),
+    ("contacts", "/contacts", {}, None),
+    ("vendors", "/vendors", {}, None),
+    ("products", "/products", {}, None),
+    ("leads", "/leads", {}, None),
+    ("tickets", "/tickets", {}, "updated_at"),
+    ("invoices", "/invoices", {}, "updated_at"),
+    ("estimates", "/estimates", {}, None),
+    ("payments", "/payments", {}, None),
+    ("purchase_orders", "/purchase_orders", {}, None),
+    ("portal_users", "/portal_users", {}, None),
+    ("customer_assets", "/customer_assets", {}, None),
+    ("appointments", "/appointments", {}, None),
+    ("canned_responses", "/canned_responses", {}, None),
+    ("contracts", "/contracts", {}, None),
+    ("schedules", "/schedules", {}, None),
+    ("rmm_alerts", "/rmm_alerts", {}, None),
+    ("wiki_pages", "/wiki_pages", {}, None),
+]
+
+
+def _upsert(model_cls, payload: Dict[str, Any]) -> None:
+    if model_cls is None:
+        return
+    obj = model_cls.query.get(payload["id"]) if payload.get("id") else None
+    if not obj:
+        obj = model_cls(id=payload["id"])
+    for col in model_cls.__table__.columns.keys():
+        if col == "id":
+            continue
+        if col in payload:
+            setattr(obj, col, payload[col])
+    db.session.merge(obj)
+    db.session.commit()
+
+
+MODEL_MAP = {}
+
+
+def _register_models():
+    from app import models as m
+
+    MODEL_MAP.update(
+        {
+            "products": getattr(m, "RSProduct", None),
+            "customers": getattr(m, "RSCustomer", None),
+            "vendors": getattr(m, "RSVendor", None),
+            "invoices": getattr(m, "RSInvoice", None),
+            "estimates": getattr(m, "RSEstimate", None),
+            "line_items_invoices": getattr(m, "RSLineItem", None),
+            "line_items_estimates": getattr(m, "RSLineItem", None),
+            "purchase_orders": getattr(m, "RSPurchaseOrder", None),
+        }
+    )
+
+
+def export_stream(
+    client: RepairShoprClient,
+    name: str,
+    path: str,
+    params: Optional[Dict[str, Any]],
+    cursor_field: Optional[str],
+    cp: CheckpointStore,
+    export_to_db: bool,
+) -> Tuple[int, Optional[str], list[int]]:
+    start = cp.get(name)
+    page = start.get("page", 0) + 1
+    cursor = start.get("cursor")
+    if cursor and cursor_field:
+        params = dict(params or {})
+        params["since_updated_at"] = cursor
+    out = Path(EXPORT_DIR) / f"{name}.jsonl"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    total = 0
+    seen_ids: list[int] = []
+    cursor_val: Optional[str] = cursor
+    with open(out, "a", encoding="utf-8") as fh:
+        for pg, items in client.paginate(path, params=params, start_page=page):
+            for item in items:
+                fh.write(json.dumps(item) + "\n")
+                total += 1
+                if export_to_db:
+                    _upsert(MODEL_MAP.get(name), item)
+                if name == "products" and item.get("id"):
+                    seen_ids.append(int(item["id"]))
+                if cursor_field and item.get(cursor_field):
+                    val = item[cursor_field]
+                    if not cursor_val or val > cursor_val:
+                        cursor_val = val
+            cp.save(name, pg, cursor_val)
+            logging.info(
+                "%s page=%s total=%s rpm=%.1f", name, pg, total, client.current_rpm()
+            )
+    return total, cursor_val, seen_ids
+
+
+def export_line_items(client: RepairShoprClient, cp: CheckpointStore, export_to_db: bool) -> None:
+    for key, param in (
+        ("line_items_invoices", {"invoice_id_not_null": "true"}),
+        ("line_items_estimates", {"estimate_id_not_null": "true"}),
+    ):
+        export_stream(client, key, "/line_items", param, None, cp, export_to_db)
+
+
+def export_product_serials(
+    client: RepairShoprClient,
+    product_ids: Iterable[int],
+    cp: CheckpointStore,
+) -> None:
+    state = cp.get("product_serials")
+    start_index = state.get("product_index", 0)
+    page = state.get("page", 0) + 1
+    ids = list(product_ids)
+    out = Path(EXPORT_DIR) / "product_serials.jsonl"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    with open(out, "a", encoding="utf-8") as fh:
+        for idx in range(start_index, len(ids)):
+            pid = ids[idx]
+            pg = page
+            while True:
+                data = client.get(
+                    f"/products/{pid}/product_serials",
+                    params={"page": pg},
+                    tokens=2,
+                )
+                items = data.get("product_serials") or data.get("data") or []
+                if not items:
+                    break
+                for item in items:
+                    item["product_id"] = pid
+                    fh.write(json.dumps(item) + "\n")
+                cp.save("product_serials", idx, str(pg))
+                logging.info(
+                    "product_serials product=%s page=%s rpm=%.1f", pid, pg, client.current_rpm()
+                )
+                pg += 1
+            page = 1
+    cp.save("product_serials", len(ids), "")
+
+
+@click.group("rs-export")
+def rs_export_cli() -> None:
+    """RepairShopr export commands."""
+
+
+@rs_export_cli.command("full")
+@click.option("--include-serials", is_flag=True, help="Include product serials")
+def full_command(include_serials: bool) -> None:
+    full_export(include_serials=include_serials)
+
+
+def full_export(include_serials: bool = False) -> None:
+    logging.basicConfig(level=logging.INFO)
+    _register_models()
+    client = RepairShoprClient()
+    export_to_db = os.getenv("REPAIRSHOPR_EXPORT_TO_DB", "false").lower() == "true"
+    cp = CheckpointStore(Path(EXPORT_DIR) / "checkpoint.json")
+    all_product_ids: list[int] = []
+    for name, path, params, cursor_field in STREAMS:
+        _, _, ids = export_stream(
+            client, name, path, params, cursor_field, cp, export_to_db
+        )
+        if name == "products":
+            all_product_ids = ids
+    export_line_items(client, cp, export_to_db)
+    if include_serials and all_product_ids:
+        export_product_serials(client, all_product_ids, cp)

--- a/app/models.py
+++ b/app/models.py
@@ -65,3 +65,120 @@ class EstimateItem(db.Model):
     @property
     def line_total(self):
         return self.quantity * self.unit_price
+
+class RSProduct(db.Model):
+    __tablename__ = 'rs_product'
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String)
+    description = db.Column(db.Text)
+    long_description = db.Column(db.Text)
+    price_cost = db.Column(db.Float)
+    price_retail = db.Column(db.Float)
+    price_wholesale = db.Column(db.Float)
+    quantity = db.Column(db.Float)
+    desired_stock_level = db.Column(db.Float)
+    reorder_at = db.Column(db.Float)
+    maintain_stock = db.Column(db.Boolean)
+    taxable = db.Column(db.Boolean)
+    serialized = db.Column(db.Boolean)
+    upc_code = db.Column(db.String)
+    category_path = db.Column(db.String)
+    product_category = db.Column(db.String)
+    vendor_ids = db.Column(db.JSON)
+    photos = db.Column(db.JSON)
+    location_quantities = db.Column(db.JSON)
+    sku = db.Column(db.String, nullable=True)
+
+
+class RSCustomer(db.Model):
+    __tablename__ = 'rs_customer'
+    id = db.Column(db.Integer, primary_key=True)
+    firstname = db.Column(db.String)
+    lastname = db.Column(db.String)
+    fullname = db.Column(db.String)
+    business_name = db.Column(db.String)
+    email = db.Column(db.String)
+    phone = db.Column(db.String)
+    mobile = db.Column(db.String)
+    address = db.Column(db.String)
+    address2 = db.Column(db.String)
+    city = db.Column(db.String)
+    state = db.Column(db.String)
+    zip = db.Column(db.String)
+    created_at = db.Column(db.String)
+    updated_at = db.Column(db.String)
+    disabled = db.Column(db.Boolean)
+    properties = db.Column(db.JSON)
+    tax_rate_id = db.Column(db.Integer)
+
+
+class RSVendor(db.Model):
+    __tablename__ = 'rs_vendor'
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String)
+    email = db.Column(db.String)
+
+
+class RSInvoice(db.Model):
+    __tablename__ = 'rs_invoice'
+    id = db.Column(db.Integer, primary_key=True)
+    number = db.Column(db.String)
+    status = db.Column(db.String)
+    date = db.Column(db.String)
+    due_date = db.Column(db.String)
+    subtotal = db.Column(db.Float)
+    total = db.Column(db.Float)
+    tax = db.Column(db.Float)
+    customer_id = db.Column(db.Integer)
+    ticket_id = db.Column(db.Integer)
+    pdf_url = db.Column(db.String)
+    location_id = db.Column(db.Integer)
+    created_at = db.Column(db.String)
+    updated_at = db.Column(db.String)
+
+
+class RSEstimate(db.Model):
+    __tablename__ = 'rs_estimate'
+    id = db.Column(db.Integer, primary_key=True)
+    number = db.Column(db.String)
+    status = db.Column(db.String)
+    date = db.Column(db.String)
+    subtotal = db.Column(db.Float)
+    total = db.Column(db.Float)
+    tax = db.Column(db.Float)
+    customer_id = db.Column(db.Integer)
+    ticket_id = db.Column(db.Integer)
+    pdf_url = db.Column(db.String)
+    location_id = db.Column(db.Integer)
+    created_at = db.Column(db.String)
+    updated_at = db.Column(db.String)
+
+
+class RSLineItem(db.Model):
+    __tablename__ = 'rs_line_item'
+    id = db.Column(db.Integer, primary_key=True)
+    invoice_id = db.Column(db.Integer, nullable=True)
+    estimate_id = db.Column(db.Integer, nullable=True)
+    item = db.Column(db.String)
+    name = db.Column(db.String)
+    cost = db.Column(db.Float)
+    price = db.Column(db.Float)
+    quantity = db.Column(db.Float)
+    product_id = db.Column(db.Integer)
+    taxable = db.Column(db.Boolean)
+    discount_percent = db.Column(db.Float)
+    discount_dollars = db.Column(db.Float)
+    position = db.Column(db.Integer)
+
+
+class RSPurchaseOrder(db.Model):
+    __tablename__ = 'rs_purchase_order'
+    id = db.Column(db.Integer, primary_key=True)
+    vendor_id = db.Column(db.Integer)
+    number = db.Column(db.String)
+    status = db.Column(db.String)
+    expected_date = db.Column(db.String)
+    total = db.Column(db.Float)
+    shipping = db.Column(db.Float)
+    other = db.Column(db.Float)
+    line_items = db.Column(db.JSON)

--- a/app/repairshopr_client.py
+++ b/app/repairshopr_client.py
@@ -1,91 +1,28 @@
-"""HTTP client for RepairShopr API with global rate limiter."""
-
+"""Compatibility layer for RepairShopr API access using shared rate limiter."""
 from __future__ import annotations
 
-import os
-import random
-import threading
-import time
-from typing import List, Dict
+from typing import Dict, List
 
-import requests
+from app.integrations.repairshopr_export import RepairShoprClient, TokenBucket, bucket
 
-SUBDOMAIN = os.environ["REPAIRSHOPR_SUBDOMAIN"]
-API_KEY = os.environ["REPAIRSHOPR_API_KEY"]
-API_BASE = f"https://{SUBDOMAIN}.repairshopr.com/api/v1"
-
-
-class TokenBucket:
-    def __init__(self, capacity: int = 120, refill_per_min: int = 120) -> None:
-        self.capacity = capacity
-        self.tokens = capacity
-        self.refill_rate = refill_per_min / 60.0
-        self.last = time.monotonic()
-        self.lock = threading.Lock()
-
-    def acquire(self) -> None:
-        with self.lock:
-            now = time.monotonic()
-            self.tokens = min(
-                self.capacity, self.tokens + (now - self.last) * self.refill_rate
-            )
-            self.last = now
-            if self.tokens >= 1:
-                self.tokens -= 1
-                return
-        # sleep outside the lock to avoid blocking producers
-        time.sleep(0.55 + random.random() * 0.05)
-
-
-bucket = TokenBucket(capacity=120, refill_per_min=120)
-
-
-def session() -> requests.Session:
-    s = requests.Session()
-    s.headers.update(
-        {"Authorization": f"Bearer {API_KEY}", "Accept": "application/json"}
-    )
-    return s
-
-
-def get_with_retries(url: str, params: dict | None = None) -> requests.Response:
-    tries, backoff = 0, 0.5
-    while True:
-        bucket.acquire()
-        r = session().get(url, params=params, timeout=(5, 15))
-        if r.status_code < 500 and r.status_code != 429:
-            r.raise_for_status()
-            return r
-        tries += 1
-        if tries >= 3:
-            r.raise_for_status()
-        time.sleep(backoff + random.random() * 0.2)
-        backoff = min(backoff * 2, 10.0)
+client = RepairShoprClient()
 
 
 def fetch_products_page(page: int, sort: str = "id ASC") -> List[Dict]:
-    r = get_with_retries(f"{API_BASE}/products", params={"page": page, "sort": sort})
-    data = r.json()
+    data = client.get("/products", params={"page": page, "sort": sort})
     return data.get("products") or data.get("data") or []
 
 
 def fetch_by_barcode(barcode: str) -> Dict | None:
-    r = get_with_retries(
-        f"{API_BASE}/products/barcode", params={"barcode": barcode}
-    )
-    data = r.json()
+    data = client.get("/products/barcode", params={"barcode": barcode})
     return data.get("product") or data
 
 
 def fetch_by_sku(sku: str) -> List[Dict]:
-    r = get_with_retries(f"{API_BASE}/products", params={"sku": sku, "page": 1})
-    data = r.json()
+    data = client.get("/products", params={"sku": sku, "page": 1})
     return data.get("products") or data.get("data") or []
 
 
 def fetch_by_query(query: str) -> List[Dict]:
-    r = get_with_retries(f"{API_BASE}/products", params={"query": query, "page": 1})
-    data = r.json()
+    data = client.get("/products", params={"query": query, "page": 1})
     return data.get("products") or data.get("data") or []
-
-

--- a/tests/test_repairshopr_export.py
+++ b/tests/test_repairshopr_export.py
@@ -1,0 +1,101 @@
+import os
+import time
+
+import pytest
+
+from app.integrations import repairshopr_export as rs
+
+
+os.environ.setdefault("REPAIRSHOPR_SUBDOMAIN", "test")
+os.environ.setdefault("REPAIRSHOPR_API_KEY", "key")
+
+
+def test_paginate_stops(monkeypatch):
+    client = rs.RepairShoprClient()
+    responses = [
+        {"customers": [{"id": 1}], "meta": {"total_pages": 2}},
+        {"customers": [{"id": 2}], "meta": {"total_pages": 2}},
+    ]
+
+    def fake_get(path, params=None, tokens=1):
+        page = params["page"]
+        if page <= len(responses):
+            return responses[page - 1]
+        return {"customers": []}
+
+    monkeypatch.setattr(client, "get", fake_get)
+    pages = list(client.paginate("/customers"))
+    assert len(pages) == 2
+    assert pages[0][0] == 1 and pages[1][0] == 2
+
+
+def test_limiter_behaviour():
+    bucket = rs.TokenBucket(capacity=2, refill_per_min=120)
+    start = time.monotonic()
+    bucket.acquire()
+    bucket.acquire()
+    bucket.acquire()
+    assert time.monotonic() - start >= 0.5
+
+
+class DummyResponse:
+    def __init__(self, status_code, data=None):
+        self.status_code = status_code
+        self._data = data or {"ok": True}
+
+    def json(self):
+        return self._data
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise Exception(self.status_code)
+
+
+def test_backoff_on_429(monkeypatch):
+    client = rs.RepairShoprClient()
+    calls = []
+    seq = [DummyResponse(429), DummyResponse(500), DummyResponse(200)]
+
+    def fake_get(url, params=None, timeout=None):
+        resp = seq[len(calls)]
+        calls.append(1)
+        return resp
+
+    sleeps = []
+    monkeypatch.setattr(rs, "bucket", type("B", (), {"acquire": lambda self, n=1: None})())
+    monkeypatch.setattr(client.session, "get", fake_get)
+    monkeypatch.setattr(rs.time, "sleep", lambda s: sleeps.append(s))
+    data = client.get("/x")
+    assert data["ok"] is True
+    assert len(calls) == 3
+    assert len(sleeps) == 2
+    assert sleeps[1] > sleeps[0]
+
+
+def test_checkpoint_resume(tmp_path, monkeypatch):
+    cp = rs.CheckpointStore(tmp_path / "ck.json")
+    cp.save("stream", 1)
+    client = rs.RepairShoprClient()
+
+    def fake_paginate(path, params=None, start_page=1, tokens=1):
+        assert start_page == 2
+        yield start_page, [{"id": 2}]
+
+    monkeypatch.setattr(client, "paginate", fake_paginate)
+    rs.export_stream(client, "stream", "/s", {}, None, cp, False)
+    assert cp.get("stream")["page"] == 2
+
+
+def test_line_items_queries(monkeypatch, tmp_path):
+    client = rs.RepairShoprClient()
+    cp = rs.CheckpointStore(tmp_path / "ck.json")
+    calls = []
+
+    def fake_export_stream(client, name, path, params, cursor_field, cp, export_to_db):
+        calls.append((name, params))
+        return 0, None, []
+
+    monkeypatch.setattr(rs, "export_stream", fake_export_stream)
+    rs.export_line_items(client, cp, False)
+    assert ("line_items_invoices", {"invoice_id_not_null": "true"}) in calls
+    assert ("line_items_estimates", {"estimate_id_not_null": "true"}) in calls


### PR DESCRIPTION
## Summary
- Implement `RepairShoprClient` with global token-bucket limiter, pagination, and checkpoints
- Add CLI `flask rs-export full` to export multiple RepairShopr streams with optional DB upsert
- Introduce SQLAlchemy models for RepairShopr entities and unit tests for export mechanics

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bae0905a388330aa218d0632b466c7