### PR TITLE
Improve bundle table formatting and reordering

### DIFF
--- a/app/templates/bundles/edit.html
+++ b/app/templates/bundles/edit.html
@@ -32,16 +32,16 @@
     <tr>
       <th style="width:25%">Product</th>
       <th style="width:45%">Description</th>
-      <th style="width:10%">Qty</th>
-      <th style="width:10%">Stock</th>
       <th style="width:10%">Cost</th>
       <th style="width:10%">Retail</th>
-      <th style="width:10%">Actions</th>
+      <th style="width:10%">Qty</th>
+      <th style="width:10%">Stock</th>
+      <th style="width:10%"></th>
     </tr>
   </thead>
   <tbody id="bundle-items" data-bundle-id="{{ bundle.id }}">
     {% for item in bundle.items %}
-    <tr data-item-id="{{ item.id }}" class="{% if item.stock == 0 %}table-danger{% endif %}">
+    <tr data-item-id="{{ item.id }}" class="{% if item.stock == 0 %}table-danger{% endif %}" draggable="true">
       <td>
         <input type="text" name="product_name" class="form-control"
                value="{{ item.product_name }}">
@@ -51,18 +51,24 @@
                value="{{ item.description }}">
       </td>
       <td>
+        <div class="input-group">
+          <span class="input-group-text">$</span>
+          <input type="text" name="cost" class="form-control"
+                 value="{{ "{:.2f}".format(item.unit_price) }}">
+        </div>
+      </td>
+      <td>
+        <div class="input-group">
+          <span class="input-group-text">$</span>
+          <input type="text" name="retail" class="form-control"
+                 value="{{ "{:.2f}".format(item.retail) }}">
+        </div>
+      </td>
+      <td>
         <input type="number" name="quantity" class="form-control"
                min="0" value="{{ item.quantity }}">
       </td>
       <td class="stock-cell">{{ item.stock }}</td>
-      <td>
-        <input type="text" name="cost" class="form-control"
-               value="{{ "{:.2f}".format(item.unit_price) }}">
-      </td>
-      <td>
-        <input type="text" name="retail" class="form-control"
-               value="{{ "{:.2f}".format(item.retail) }}">
-      </td>
       <td>
         <button class="btn btn-sm btn-danger remove-item">&times;</button>
       </td>

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,1 +1,9 @@
 body { padding-top: 1rem; }
+
+.table-danger {
+  background-color: #ff6b6b !important;
+}
+
+#bundle-items tr {
+  cursor: move;
+}

--- a/static/js/bundles.js
+++ b/static/js/bundles.js
@@ -10,6 +10,7 @@ document.addEventListener('DOMContentLoaded', () => {
   let debounce;
   let abortCtrl;
   let page = 1;
+  let draggedRow;
 
   function recalcTotals() {
     let totalCost = 0, totalRetail = 0;
@@ -131,13 +132,14 @@ document.addEventListener('DOMContentLoaded', () => {
 
       const row = document.createElement('tr');
       row.dataset.itemId = item_id;
+      row.draggable = true;
       row.innerHTML = `
         <td><input type="text" name="product_name" class="form-control" value="${name}"></td>
         <td><input type="text" name="description" class="form-control" value="${desc}"></td>
+        <td><div class="input-group"><span class="input-group-text">$</span><input type="text" name="cost" class="form-control" value="${cost.toFixed(2)}"></div></td>
+        <td><div class="input-group"><span class="input-group-text">$</span><input type="text" name="retail" class="form-control" value="${retail.toFixed(2)}"></div></td>
         <td><input type="number" name="quantity" class="form-control" min="0" value="${quantity}"></td>
         <td class="stock-cell">${stock}</td>
-        <td><input type="text" name="cost" class="form-control" value="${cost.toFixed(2)}"></td>
-        <td><input type="text" name="retail" class="form-control" value="${retail.toFixed(2)}"></td>
         <td><button class="btn btn-sm btn-danger remove-item">&times;</button></td>
       `;
       row.classList.toggle('table-danger', stock === 0);
@@ -203,5 +205,22 @@ document.addEventListener('DOMContentLoaded', () => {
     } catch (err) {
       console.error('Update-item error:', err);
     }
+  });
+
+  itemsBody.addEventListener('dragstart', e => {
+    draggedRow = e.target.closest('tr');
+  });
+
+  itemsBody.addEventListener('dragover', e => {
+    e.preventDefault();
+    const target = e.target.closest('tr');
+    if (!target || target === draggedRow) return;
+    const rect = target.getBoundingClientRect();
+    const next = (e.clientY - rect.top) / (rect.height) > 0.5;
+    itemsBody.insertBefore(draggedRow, next ? target.nextSibling : target);
+  });
+
+  itemsBody.addEventListener('dragend', () => {
+    draggedRow = null;
   });
 });


### PR DESCRIPTION
## Summary
- Reorder bundle edit table to show cost/retail before quantity and drop header text for actions
- Display cost and retail inputs with dollar formatting and brighter out-of-stock highlighting
- Enable drag-and-drop to rearrange bundle items

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68baef7094d4833092f08fe3d2d80a56