### PR TITLE
Add hover text to Update Bundle button

### DIFF
--- a/app/templates/bundles/edit.html
+++ b/app/templates/bundles/edit.html
@@ -16,7 +16,7 @@
               class="form-control">{{ bundle.description }}</textarea>
   </div>
   <button type="submit" class="btn btn-primary">Save Bundle</button>
-  <button type="button" id="update-bundle" class="btn btn-secondary ms-2">Update Bundle</button>
+  <button type="button" id="update-bundle" class="btn btn-secondary ms-2" title="Updates the cost and stock level for each item in the bundle">Update Bundle</button>
 </form>
 
 <div class="mb-4 position-relative">


### PR DESCRIPTION
## Summary
- clarify Update Bundle action with hover text about refreshing item cost and stock levels

## Testing
- `ruff check .` *(fails: unused imports in unrelated files)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68baf3572c508330acfc224e4a12a371