### PR TITLE
Add bundle support and refresh to estimates

### DIFF
--- a/app/templates/estimates/form.html
+++ b/app/templates/estimates/form.html
@@ -54,8 +54,8 @@
       </tr>
     </thead>
     <tbody id="items-body">
-      {% if estimate %}
-        {% for it in estimate.items %}
+      {% if items %}
+        {% for it in items %}
         <tr data-item-id="{{ it.id }}" class="draggable">
           <td class="drag-handle">☰</td>
           <td>{{ it.name }}</td>
@@ -72,7 +72,7 @@
           </td>
         </tr>
         {% if it.type=='bundle' %}
-        {% for sub in it.bundle_items %}
+        {% for sub in it.children %}
         <tr data-parent-id="{{ it.id }}" class="bundle-item draggable">
           <td class="drag-handle">☰</td>
           <td class="pl-4">{{ sub.name }}</td>
@@ -96,6 +96,7 @@
   <!-- Save/Export/Push buttons unchanged -->
   <div class="mt-3">
     <button id="save-estimate" class="btn btn-primary">Save Estimate</button>
+    <button id="update-estimate" class="btn btn-secondary ms-2" title="Updates the cost of each item in the estimate">Update Estimate</button>
     <button id="export-pdf"   class="btn btn-outline-secondary">Export PDF</button>
     <button id="push-rs"      class="btn btn-outline-info">Push to RepairShopr</button>
   </div>

--- a/tests/test_estimate_math.py
+++ b/tests/test_estimate_math.py
@@ -41,3 +41,26 @@ def test_totals_and_markup():
         db.session.commit()
         assert est.total_cost == 5.0
         assert est.total_retail == 8.0
+
+
+def test_bundle_parent_children_totals():
+    app = setup_app()
+    with app.app_context():
+        est = Estimate(customer_id=None, customer_name='Test', customer_address='')
+        db.session.add(est)
+        db.session.commit()
+
+        parent = EstimateItem(estimate_id=est.id, type='bundle', object_id=99,
+                              name='Kit', description='', quantity=1,
+                              unit_price=10.0, retail=15.0)
+        db.session.add(parent)
+        db.session.flush()
+        child = EstimateItem(estimate_id=est.id, type='product', object_id=1,
+                             name='Widget', description='', quantity=2,
+                             unit_price=3.0, retail=5.0, parent_id=parent.id)
+        db.session.add(child)
+        db.session.commit()
+
+        # Only the bundle parent should contribute to totals
+        assert est.total_cost == 10.0
+        assert est.total_retail == 15.0


### PR DESCRIPTION
## Summary
- allow estimates to nest bundle items under a parent bundle line
- support refreshing estimate item costs from RepairShopr
- add test ensuring bundle children are not double counted

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68baf7b616f08330a38401c028c9fca5