### PR TITLE
Fix bundle cloning for estimate items

### DIFF
--- a/app/estimates/routes.py
+++ b/app/estimates/routes.py
@@ -108,7 +108,7 @@ def clone_bundle_endpoint(bundle_id):
 @bp.route('/<int:estimate_id>/add-item', methods=['POST'])
 def add_estimate_item(estimate_id):
     data = request.get_json()
-    est  = Estimate.query.get_or_404(estimate_id)
+    Estimate.query.get_or_404(estimate_id)
 
     if data.get('type') == 'bundle':
         bundle = Bundle.query.get_or_404(data['id'])

--- a/app/estimates/utils.py
+++ b/app/estimates/utils.py
@@ -86,12 +86,12 @@ def clone_bundle_to_items(bundle, estimate) -> list:
         clones.append(EstimateItem(
             estimate_id = (estimate.id if estimate else None),
             type        = 'product',
-            object_id   = bi.object_id,
-            name        = bi.name,
+            object_id   = bi.id,  # reference original BundleItem
+            name        = bi.product_name,
             description = bi.description,
             quantity    = bi.quantity,
             unit_price  = bi.unit_price,
             retail      = bi.retail,
-            notes       = bi.notes or ''
+            notes       = ''
         ))
     return clones

--- a/app/integrations/repairshopr_export.py
+++ b/app/integrations/repairshopr_export.py
@@ -10,7 +10,6 @@ from typing import Any, Dict, Generator, Iterable, Optional, Tuple
 
 import click
 import requests
-from flask import current_app
 
 from app import db
 
@@ -78,7 +77,7 @@ class RepairShoprClient:
             bucket.acquire(tokens)
             try:
                 r = self.session.get(url, params=params, timeout=self.timeout)
-            except requests.RequestException as e:  # network issue
+            except requests.RequestException:  # network issue
                 tries += 1
                 if tries > 3:
                     raise

--- a/app/repairshopr_client.py
+++ b/app/repairshopr_client.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Dict, List
 
-from app.integrations.repairshopr_export import RepairShoprClient, TokenBucket, bucket
+from app.integrations.repairshopr_export import RepairShoprClient
 
 client = RepairShoprClient()
 

--- a/tests/test_repairshopr_export.py
+++ b/tests/test_repairshopr_export.py
@@ -1,8 +1,6 @@
 import os
 import time
 
-import pytest
-
 from app.integrations import repairshopr_export as rs
 
 


### PR DESCRIPTION
## Summary
- Align estimate bundle cloning with `BundleItem` fields to prevent missing attribute errors
- Remove unused variables and imports discovered by lint

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bafa7bf3448330bd5d46337a802855