### PR TITLE
Refine bundle child item display

### DIFF
--- a/app/templates/estimates/form.html
+++ b/app/templates/estimates/form.html
@@ -48,7 +48,7 @@
         <th>Description</th>
         <th>Cost</th>
         <th>Retail</th>
-        <th>Qty</th>
+        <th style="width:80px;">Qty</th>
         <th>Stock</th>
         <th>Line Total</th>
         <th></th>
@@ -63,28 +63,28 @@
           <td>{{ it.description or '' }}</td>
           <td><input type="number" class="form-control unit-price" step="0.01" value="{{ it.unit_price }}"></td>
           <td><input type="number" class="form-control retail" step="0.01" value="{{ it.retail }}"></td>
-          <td><input type="number" class="form-control qty" value="{{ it.quantity }}"></td>
+          <td><input type="number" class="form-control qty" value="{{ it.quantity }}" style="width:80px;"></td>
           <td class="stock-cell">{% if it.type=='product' %}{{ it.stock or 0 }}{% else %}--{% endif %}</td>
           <td class="line-total">${{ '%.2f'|format(it.quantity * it.unit_price) }}</td>
           <td>
-            {% if it.type=='bundle' %}
-            <button class="btn btn-sm btn-outline-primary toggle-bundle" title="Show/Hide Items">&#128065;</button>
-            {% endif %}
             <button class="btn btn-sm btn-danger remove-item">✕</button>
+            {% if it.type=='bundle' %}
+            <button class="btn btn-sm btn-outline-primary toggle-bundle ms-1" title="Show/Hide Items">&#128065;</button>
+            {% endif %}
           </td>
         </tr>
         {% if it.type=='bundle' %}
         {% for sub in it.children %}
         <tr data-parent-id="{{ it.id }}" data-type="product" data-qty="{{ sub.quantity }}" class="bundle-item draggable{% if (sub.stock or 0) < sub.quantity %} table-danger{% endif %}" draggable="true">
-          <td>☰</td>
+          <td>—</td>
           <td class="ps-4">{{ sub.name }}</td>
           <td>{{ sub.description or '' }}</td>
           <td><input type="number" class="form-control unit-price" step="0.01" value="{{ sub.unit_price }}"></td>
           <td><input type="number" class="form-control retail" step="0.01" value="{{ sub.retail }}"></td>
-          <td><input type="number" class="form-control qty" value="{{ sub.quantity }}"></td>
+          <td><input type="number" class="form-control qty" value="{{ sub.quantity }}" style="width:80px;"></td>
           <td class="stock-cell">{{ sub.stock or 0 }}</td>
           <td class="line-total">${{ '%.2f'|format(sub.quantity * sub.unit_price) }}</td>
-          <td><button class="btn btn-sm btn-danger remove-item">✕</button></td>
+          <td></td>
         </tr>
         {% endfor %}
         {% endif %}

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -7,3 +7,7 @@ body { padding-top: 1rem; }
 #bundle-items tr {
   cursor: move;
 }
+
+#items-table .qty {
+  width: 80px;
+}

--- a/static/js/estimates.js
+++ b/static/js/estimates.js
@@ -248,7 +248,7 @@ bsSug.addEventListener('click', async e => {
 
     const dragTd = document.createElement('td');
     dragTd.className = 'drag-handle';
-    dragTd.textContent = '☰';
+    dragTd.textContent = parentId ? '—' : '☰';
     tr.appendChild(dragTd);
 
     const nameTd = document.createElement('td');
@@ -267,6 +267,7 @@ bsSug.addEventListener('click', async e => {
       inp.step      = (field === 'quantity' ? '1' : '0.01');
       inp.className = 'form-control ' + (field === 'quantity' ? 'qty' : field.replace('_','-'));
       inp.value     = data[field] ?? (field === 'quantity' ? 1 : 0);
+      if (field === 'quantity') inp.style.width = '80px';
       td.appendChild(inp);
       tr.appendChild(td);
     }
@@ -282,17 +283,20 @@ bsSug.addEventListener('click', async e => {
     tr.appendChild(lineTd);
 
     const actTd = document.createElement('td');
+    if (!parentId) {
+      const remBtn = document.createElement('button');
+      remBtn.className = 'btn btn-sm btn-danger remove-item';
+      remBtn.textContent = '✕';
+      actTd.appendChild(remBtn);
+    }
     if (data.type === 'bundle') {
       const toggleBtn = document.createElement('button');
       toggleBtn.className = 'btn btn-sm btn-outline-primary toggle-bundle';
       toggleBtn.innerHTML = '&#128065;';
       toggleBtn.title = 'Show/Hide Items';
+      if (!parentId) toggleBtn.classList.add('ms-1');
       actTd.appendChild(toggleBtn);
     }
-    const remBtn = document.createElement('button');
-    remBtn.className = 'btn btn-sm btn-danger remove-item';
-    remBtn.textContent = '✕';
-    actTd.appendChild(remBtn);
     tr.appendChild(actTd);
 
     const stockVal = data.type === 'product' ? (+data.stock || 0) : null;


### PR DESCRIPTION
## Summary
- Show bundle child rows with a single-line drag handle and no remove button
- Reposition bundle show/hide control beside removal button
- Reduce quantity column width for compact layout

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bb0456b1a08330a387be13db9d1ea4