### PR TITLE
Adjust bundle pricing to follow child items

### DIFF
--- a/app/templates/estimates/form.html
+++ b/app/templates/estimates/form.html
@@ -57,15 +57,15 @@
     <tbody id="items-body">
       {% if items %}
         {% for it in items %}
-        <tr data-item-id="{{ it.id }}" data-type="{{ it.type }}" data-qty="{{ it.quantity }}" class="draggable{% if it.type=='product' and (it.stock or 0) < it.quantity %} table-danger{% endif %}" draggable="true">
+        <tr data-item-id="{{ it.id }}" data-type="{{ it.type }}" data-qty="{{ it.quantity }}" class="draggable{% if it.type=='product' and (it.stock or 0) > 0 and (it.stock or 0) < it.quantity %} table-danger{% endif %}" draggable="true">
           <td>☰</td>
           <td>{{ it.name }}</td>
           <td>{{ it.description or '' }}</td>
-          <td><input type="number" class="form-control unit-price" step="0.01" value="{{ it.unit_price }}"></td>
-          <td><input type="number" class="form-control retail" step="0.01" value="{{ it.retail }}"></td>
-          <td><input type="number" class="form-control qty" value="{{ it.quantity }}" style="width:80px;"></td>
+          <td><input type="number" class="form-control unit-price" step="0.01" value="{{ it.unit_price }}"{% if it.type=='bundle' %} readonly{% endif %}></td>
+          <td><input type="number" class="form-control retail" step="0.01" value="{{ it.retail }}"{% if it.type=='bundle' %} readonly{% endif %}></td>
+          <td><input type="number" class="form-control qty" value="{{ it.quantity }}" min="0" style="width:80px;"></td>
           <td class="stock-cell">{% if it.type=='product' %}{{ it.stock or 0 }}{% else %}--{% endif %}</td>
-          <td class="line-total">${{ '%.2f'|format(it.quantity * it.retail) }}</td>
+          <td class="line-total">{% if it.type=='product' and (it.stock or 0) == 0 %}<strong class="text-danger">!</strong>{% endif %}${{ '%.2f'|format(it.quantity * it.retail) }}</td>
           <td>
             <button class="btn btn-sm btn-danger remove-item">✕</button>
             {% if it.type=='bundle' %}
@@ -75,15 +75,15 @@
         </tr>
         {% if it.type=='bundle' %}
         {% for sub in it.children %}
-        <tr data-parent-id="{{ it.id }}" data-type="product" data-qty="{{ sub.quantity }}" class="bundle-item draggable{% if (sub.stock or 0) < sub.quantity %} table-danger{% endif %}" draggable="true">
+        <tr data-parent-id="{{ it.id }}" data-type="product" data-qty="{{ sub.quantity }}" class="bundle-item draggable{% if (sub.stock or 0) > 0 and (sub.stock or 0) < sub.quantity %} table-danger{% endif %}" draggable="true">
           <td>—</td>
           <td class="ps-4">{{ sub.name }}</td>
           <td>{{ sub.description or '' }}</td>
           <td><input type="number" class="form-control unit-price" step="0.01" value="{{ sub.unit_price }}"></td>
           <td><input type="number" class="form-control retail" step="0.01" value="{{ sub.retail }}"></td>
-          <td><input type="number" class="form-control qty" value="{{ sub.quantity }}" style="width:80px;"></td>
+          <td><input type="number" class="form-control qty" value="{{ sub.quantity }}" min="0" style="width:80px;"></td>
           <td class="stock-cell">{{ sub.stock or 0 }}</td>
-          <td class="line-total">${{ '%.2f'|format(sub.quantity * sub.retail) }}</td>
+          <td class="line-total">{% if (sub.stock or 0) == 0 %}<strong class="text-danger">!</strong>{% endif %}${{ '%.2f'|format(sub.quantity * sub.retail) }}</td>
           <td></td>
         </tr>
         {% endfor %}

--- a/tests/test_bundle_child_zero.py
+++ b/tests/test_bundle_child_zero.py
@@ -1,0 +1,43 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from app import create_app, db
+from app.models import Estimate, EstimateItem
+
+
+def setup_app():
+    os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
+    app = create_app('development')
+    app.config.update(SQLALCHEMY_DATABASE_URI='sqlite:///:memory:')
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+    return app
+
+
+def test_child_qty_zero_updates_parent():
+    app = setup_app()
+    with app.app_context():
+        est = Estimate(customer_id=None, customer_name='Test', customer_address='')
+        db.session.add(est)
+        db.session.commit()
+        parent = EstimateItem(estimate_id=est.id, type='bundle', object_id=1,
+                              name='Kit', description='', quantity=1,
+                              unit_price=5.0, retail=10.0)
+        db.session.add(parent)
+        db.session.flush()
+        child = EstimateItem(estimate_id=est.id, type='product', object_id=2,
+                             name='Widget', description='', quantity=1,
+                             unit_price=5.0, retail=10.0, parent_id=parent.id)
+        db.session.add(child)
+        db.session.commit()
+
+        client = app.test_client()
+        resp = client.post(f'/estimates/{est.id}/update-item/{child.id}',
+                           json={'quantity': 0})
+        assert resp.status_code == 200
+        db.session.refresh(parent)
+        assert parent.unit_price == 0
+        assert parent.retail == 0


### PR DESCRIPTION
## Summary
- Recompute bundle parent cost/retail whenever a child item changes
- Prevent editing bundle cost/retail in estimate UI and display zero-stock notice
- Allow child items to have zero quantity and update parent pricing accordingly

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb0c2f03a48330875a515a9858c532