### PR TITLE
Rename Item column to Product and flag zero-stock pricing

### DIFF
--- a/app/templates/estimates/form.html
+++ b/app/templates/estimates/form.html
@@ -44,7 +44,7 @@
     <thead>
       <tr>
         <th></th>
-        <th>Item</th>
+        <th>Product</th>
         <th>Description</th>
         <th>Cost ($)</th>
         <th>Retail ($)</th>
@@ -87,7 +87,7 @@
           </td>
           <td><input type="number" class="form-control qty" value="{{ it.quantity }}" min="0" style="width:80px;"></td>
           <td class="stock-cell">{% if it.type=='product' %}{{ it.stock or 0 }}{% else %}--{% endif %}</td>
-          <td class="line-total">{% if it.type=='product' and (it.stock or 0) <= 0 %}<strong class="text-danger">!</strong>{% endif %}${{ '%.2f'|format(it.quantity * it.retail) }}</td>
+          <td class="line-total{% if it.type=='product' and (it.stock or 0) <= 0 %} bg-danger text-white{% endif %}">${{ '%.2f'|format(it.quantity * it.retail) }}</td>
           <td>
             <button class="btn btn-sm btn-danger remove-item">✕</button>
             {% if it.type=='bundle' %}
@@ -115,7 +115,7 @@
           </td>
           <td><input type="number" class="form-control qty" value="{{ sub.quantity }}" min="0" style="width:80px;"></td>
           <td class="stock-cell">{{ sub.stock or 0 }}</td>
-          <td class="line-total">{% if (sub.stock or 0) <= 0 %}<strong class="text-danger">!</strong>{% endif %}${{ '%.2f'|format(sub.quantity * sub.retail) }}</td>
+          <td class="line-total{% if (sub.stock or 0) <= 0 %} bg-danger text-white{% endif %}">${{ '%.2f'|format(sub.quantity * sub.retail) }}</td>
           <td></td>
         </tr>
         {% endfor %}

--- a/static/js/estimates.js
+++ b/static/js/estimates.js
@@ -314,10 +314,10 @@ bsSug.addEventListener('click', async e => {
     tr.appendChild(stockTd);
 
     const lineTd = document.createElement('td');
-    lineTd.className = 'line-total';
     const noStock = data.type === 'product' && data.stock !== undefined && data.stock <= 0;
+    lineTd.className = 'line-total' + (noStock ? ' bg-danger text-white' : '');
     const lineVal = ((data.quantity || 1) * (data.retail || 0)).toFixed(2);
-    lineTd.innerHTML = `${noStock ? '<strong class="text-danger">!</strong>' : ''}$${lineVal}`;
+    lineTd.textContent = `$${lineVal}`;
     tr.appendChild(lineTd);
 
     const actTd = document.createElement('td');
@@ -376,7 +376,9 @@ bsSug.addEventListener('click', async e => {
       const noStock = stock !== null && !isNaN(stock) && stock <= 0;
       const insufficient = stock !== null && !isNaN(stock) && stock > 0 && stock < q;
       const lineCell = row.querySelector('.line-total');
-      lineCell.innerHTML = `${noStock ? '<strong class="text-danger">!</strong>' : ''}$${ltRetail.toFixed(2)}`;
+      lineCell.textContent = `$${ltRetail.toFixed(2)}`;
+      lineCell.classList.toggle('bg-danger', noStock);
+      lineCell.classList.toggle('text-white', noStock);
       row.classList.toggle('table-danger', insufficient);
       if (row.dataset.parentId) return; // child rows don't count toward totals
       totalCost   += q * c;


### PR DESCRIPTION
## Summary
- Rename the Item column to Product on the estimate form
- Highlight the line item price cell in red when a product's stock is zero

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb117846dc8330b5a5b9c6b14e29d1