### PR TITLE
Add customer search and RepairShopr estimate push

### DIFF
--- a/app/api/repairshopr.py
+++ b/app/api/repairshopr.py
@@ -106,3 +106,53 @@ def get_customer(customer_id):
     except RequestException as e:
         print(f"⚠️ RepairShopr network error: {e}")
     return None
+
+
+def get_last_estimate():
+    """Return the most recently created estimate from RepairShopr."""
+    headers = {
+        'Authorization': f'Bearer {API_KEY}',
+        'Accept': 'application/json'
+    }
+    try:
+        resp = requests.get(
+            f"{API_URL}/estimates",
+            params={'per_page': 1, 'sort': 'id DESC'},
+            headers=headers,
+        )
+        resp.raise_for_status()
+        payload = resp.json()
+        ests = payload.get('estimates') or payload.get('data') or []
+        return ests[0] if ests else None
+    except HTTPError as e:
+        print(f"⚠️ RepairShopr API error ({e.response.status_code}): {e}")
+    except RequestException as e:
+        print(f"⚠️ RepairShopr network error: {e}")
+    return None
+
+
+def create_estimate(customer_id, line_items, number=None):
+    """Create a new estimate with ``line_items`` in RepairShopr."""
+    headers = {
+        'Authorization': f'Bearer {API_KEY}',
+        'Accept': 'application/json',
+        'Content-Type': 'application/json',
+    }
+    payload = {
+        'estimate': {
+            'customer_id': customer_id,
+            'line_items_attributes': line_items,
+        }
+    }
+    if number is not None:
+        payload['estimate']['number'] = number
+    try:
+        resp = requests.post(f"{API_URL}/estimates", headers=headers, json=payload)
+        resp.raise_for_status()
+        data = resp.json()
+        return data.get('estimate', data)
+    except HTTPError as e:
+        print(f"⚠️ RepairShopr API error ({e.response.status_code}): {e}")
+    except RequestException as e:
+        print(f"⚠️ RepairShopr network error: {e}")
+    return None

--- a/app/templates/estimates/form.html
+++ b/app/templates/estimates/form.html
@@ -5,8 +5,27 @@
     {% if estimate %}Edit Estimate #{{ estimate.id }}
     {% else %}New Estimate{% endif %}
   </h1>
-
-  <!-- Customer & status fields omitted for brevity -->
+  <div class="mb-3 position-relative">
+    <label for="customer-search">Customer</label>
+    <input type="hidden" id="customer-id" value="{{ estimate.customer_id or '' }}">
+    <input type="text" id="customer-search" class="form-control"
+           placeholder="Search RepairShopr customers" autocomplete="off"
+           value="{{ estimate.customer_name or '' }}">
+    <ul id="customer-suggestions" class="list-group position-absolute w-100"
+        style="z-index:1000;"></ul>
+  </div>
+  <div class="mb-3">
+    <strong>Address:</strong>
+    <div id="customer-address">{{ estimate.customer_address or '' }}</div>
+  </div>
+  <div class="mb-3">
+    <label for="status">Status</label>
+    <select id="status" class="form-select">
+      {% for st in ['draft', 'sent'] %}
+      <option value="{{ st }}" {% if estimate.status == st %}selected{% endif %}>{{ st.title() }}</option>
+      {% endfor %}
+    </select>
+  </div>
 
   <hr>
 

--- a/tests/test_push_estimate.py
+++ b/tests/test_push_estimate.py
@@ -1,0 +1,55 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from app import create_app, db
+from app.models import Estimate, EstimateItem
+from app.api import repairshopr as rs_api
+
+
+def setup_app():
+    os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
+    app = create_app('development')
+    app.config.update(SQLALCHEMY_DATABASE_URI='sqlite:///:memory:')
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+    return app
+
+
+def test_push_creates_estimate(monkeypatch):
+    app = setup_app()
+    with app.app_context():
+        est = Estimate(customer_id=1, customer_name='Cust', customer_address='A')
+        db.session.add(est)
+        db.session.commit()
+        item = EstimateItem(
+            estimate_id=est.id,
+            type='product',
+            object_id=42,
+            name='Widget',
+            description='',
+            quantity=2,
+            unit_price=10.0,
+            retail=15.0,
+        )
+        db.session.add(item)
+        db.session.commit()
+
+        called = {}
+
+        def fake_last():
+            return {'number': '100'}
+
+        def fake_create(customer_id, line_items, number=None):
+            called['args'] = (customer_id, line_items, number)
+            return {'id': 555}
+
+        monkeypatch.setattr(rs_api, 'get_last_estimate', fake_last)
+        monkeypatch.setattr(rs_api, 'create_estimate', fake_create)
+
+        client = app.test_client()
+        resp = client.post(f'/estimates/{est.id}/push')
+        assert resp.status_code == 200
+        assert called['args'][0] == 1
+        assert called['args'][1][0]['name'] == 'Widget'
+        assert called['args'][2] == 101


### PR DESCRIPTION
## Summary
- add customer search UI and attach selected customer to estimates
- enable pushing estimates to RepairShopr, creating new estimate with line items
- test pushing estimates

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb14d9210c8330bde9494260894421